### PR TITLE
fix(cert-manager): add Cloudflare API secret to network namespace

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/issuers/issuers.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/issuers/issuers.yaml
@@ -14,7 +14,6 @@ spec:
             apiTokenSecretRef:
               name: cert-manager-secret
               key: api-token
-              namespace: cert-manager
         selector:
           dnsZones:
             - "${SECRET_DOMAIN}"
@@ -35,7 +34,6 @@ spec:
             apiTokenSecretRef:
               name: cert-manager-secret
               key: api-token
-              namespace: cert-manager
         selector:
           dnsZones:
             - "${SECRET_DOMAIN}"

--- a/kubernetes/apps/network/nginx/certificates/kustomization.yaml
+++ b/kubernetes/apps/network/nginx/certificates/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./secret.sops.yaml
   - ./staging.yaml
   - ./production.yaml

--- a/kubernetes/apps/network/nginx/certificates/secret.sops.yaml
+++ b/kubernetes/apps/network/nginx/certificates/secret.sops.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: cert-manager-secret
+    namespace: network
+stringData:
+    api-token: ENC[AES256_GCM,data:1YgjZmurrNln1qyo2b9McLqnfUZ6iYVtor3XSEQxSK9u6U1gmyFY6Q==,iv:YsfAWPQ//od+sqR4J/XXIZTR9LCjuRumvtDdSDsxvCU=,tag:xYHk8hv5WiyCSkyPs5o+wg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1rc6t0klkczsvnjhpl9aghvfphqpx6ue2xdwp8rk2c2hpcy3fgv3sh7cj9l
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNM3RtV1U4RGdBTVFhMXJE
+            dUhsTUhjbW5tTjYwY2grQzVUKzA1Mmhrd0JRCkNmQlo4a2duRlRPazAwc2lNaUF1
+            U21HSEV3NXpxbGVmNEc5RHpzRS9WcmcKLS0tIG5La29GNDlZNUY5S0dYM2xVQnB3
+            TWtDL3BUWDZ4Y21VZ1lSdzdDYWZnR2sKVskvCdsnzdpGWyXbB5oEJe7ggfqgv/uy
+            jwPIyDJr1D+cOB7hmN8gAlP+NN+FecVTGRf9KKmERYgnP69lELZcNw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-01-06T16:24:48Z"
+    mac: ENC[AES256_GCM,data:9cEsrJwDzJwN6KOmt7GOo10naee07oR2BhwFLqA3tzQwHei1iYbGVap8vMVmDwwf71xDgz4pI8ODOvte6qjs59oGjWslp+iWoEHXu8zM0I8Lyr+g0kRjR9ymVq/RkjqEbwVVzbZbULedMZsRWjHhRZvIh5qLpJ03UnhTNspAGFE=,iv:NgJN039HWxM7ZteJS9yD29YLXxjgCPEKhMk6c5a7E00=,tag:UpkXsXDHqlhPGg7yOJGtGg==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1


### PR DESCRIPTION
## Summary
Add cert-manager-secret to the network namespace to fix certificate renewal

## Problem
Cert-manager v1.15.3 ClusterIssuers cannot reference secrets from other namespaces. The `namespace` field in `apiTokenSecretRef` is not supported in this version, and without it, cert-manager looks for the secret in the same namespace as the Certificate resource.

Current setup:
- Secret: `cert-manager-secret` in `cert-manager` namespace  
- Certificates: in `network` namespace
- Result: cert-manager cannot find the secret ❌

## Solution
Add the same SOPS-encrypted secret to the `network` namespace where the Certificate resources are defined. This allows cert-manager to properly access the Cloudflare API token for DNS-01 ACME challenges.

## Test plan
- [x] Secret deployed via Flux to network namespace
- [ ] Delete existing stuck challenges: `kubectl delete challenges --all -n network`
- [ ] Monitor new challenges are created and presented successfully
- [ ] Verify certificates reach `Ready=True` state

## Related
- Reverts the incorrect approach from PR #404
- Follows the pattern used in other Flux clusters for cert-manager v1.15.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)