### PR TITLE
fix(games): suspend laz-price-history CronJob

### DIFF
--- a/kubernetes/apps/games/eq/app/cronjob.yaml
+++ b/kubernetes/apps/games/eq/app/cronjob.yaml
@@ -4,6 +4,7 @@ kind: CronJob
 metadata:
   name: laz-price-history
 spec:
+  suspend: true
   schedule: "5 * * * *"
   # schedule: "*/2 * * * *"
   concurrencyPolicy: Forbid


### PR DESCRIPTION
Suspend the laz-price-history CronJob to prevent it from running scheduled jobs.