### PR TITLE
fix(postgres): update Minio endpoint port from 32771 to 32768

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
@@ -39,8 +39,8 @@ spec:
         compression: bzip2
         maxParallel: 8
       destinationPath: s3://cloudnative-pg/
-      endpointURL: "https://${NAS_IP}:32771/"
-      # Note: serverName version needs to be inclemented
+      endpointURL: "https://${NAS_IP}:32768/"
+      # Note: serverName version needs to be incremented
       # when recovering from an existing cnpg cluster
       serverName: &currentCluster postgres16-v2
       s3Credentials:


### PR DESCRIPTION
## Summary
- Updates postgres16 cluster Minio endpoint from port 32771 to 32768
- Fixes typo in comment (inclemented → incremented)

## Problem
The postgres16-2 pod was crash-looping with errors:
- `PANIC: could not locate a valid checkpoint record`
- `Can't connect to cloud provider: Could not connect to the endpoint URL: "https://10.10.96.10:32771/cloudnative-pg"`

The Minio service on the NAS (10.10.96.10) is actually running on port **32768**, not 32771.

## Solution
Updated the endpointURL to use the correct port 32768.

## Next Steps After Merge
1. Wait for Flux to reconcile the cluster configuration
2. Delete postgres16-2 PVC to force a rebuild from the healthy primary (postgres16-3)
3. The new replica should successfully restore from Minio backups

## Port Mapping (NAS)
- 0.0.0.0:32768 → Minio API (9000/tcp)
- 0.0.0.0:32769 → Minio Console (9001/tcp)