### PR TITLE
fix(external-secrets): change ClusterSecretStore from v1 to v1beta1

### DIFF
--- a/kubernetes/apps/external-secrets/external-secrets/stores/onepassword/clustersecretstore.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/stores/onepassword/clustersecretstore.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/clustersecretstore_v1beta1.json
-apiVersion: external-secrets.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: onepassword-connect


### PR DESCRIPTION
## Summary
- Fixes ClusterSecretStore apiVersion from v1 to v1beta1

## Problem
Flux reconciliation was failing with:
```
ClusterSecretStore/external-secrets/onepassword-connect dry-run failed: 
no matches for kind "ClusterSecretStore" in version "external-secrets.io/v1"
```

This was blocking the entire Flux dependency chain:
- external-secrets-stores (failed)
- cloudnative-pg (blocked)
- cloudnative-pg-cluster (blocked)
- postgres16 endpoint update couldn't apply

## Solution
Changed apiVersion from `external-secrets.io/v1` to `external-secrets.io/v1beta1` to match the installed CRD versions (v1alpha1, v1beta1).

## Impact
This unblocks Flux reconciliation and allows the postgres16 Minio endpoint fix (PR #412) to apply.